### PR TITLE
Fixing browser error "Invalid escape sequence"

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function makeApng(buffers, delay) {
     return Buffer.concat([fctl, ...fdats]);
   });
 
-  const signature = Buffer.from('\211PNG\r\n\032\n', 'ascii');
+  const signature = Buffer.from('89504e470d0a1a0a', 'hex');
   const ihdr = findChunk(buffers[0], 'IHDR');
   if (ihdr === null) {
     throw new Error('IHDR chunk not found!');


### PR DESCRIPTION
Running this code in the browser almost works as is but using the C syntax of ASCII confuses the browser with all of the `\` characters which throws an "Invalid escape sequence" error. The simplest fix I found was using the hexadecimal version of the same thing.